### PR TITLE
Remove unused Google Fonts

### DIFF
--- a/themes/plumerai-blog/layouts/partials/head.html
+++ b/themes/plumerai-blog/layouts/partials/head.html
@@ -1,6 +1,5 @@
 <head>
     <link rel="stylesheet" href="/css/main.css">
-    <link href="https://fonts.googleapis.com/css?family=Work+Sans:300,400,500,700&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png" />


### PR DESCRIPTION
#11 replaced Work Sans from Google Fonts with custom fonts, so we can remove this include.