### PR TITLE
Don't insert hero image element if no image src.

### DIFF
--- a/themes/plumerai-blog/layouts/_default/single.html
+++ b/themes/plumerai-blog/layouts/_default/single.html
@@ -1,7 +1,9 @@
 {{ define "main" }}
 
 <div class="centered-column content">
+    {{ if .Params.heroImage }}
     <img src="{{ .Params.heroImage }}" class="hero" />
+    {{ end }}
     <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
     <h2>{{ .Params.subTitle }}</h2>
     <p class="date">{{ dateFormat "Monday, January 2, 2006" .Params.date }}</p>


### PR DESCRIPTION
This should fix the problem @rnusselder noticed where the header margin is different between the homepage and the blog-post page:

<img width="907" alt="image" src="https://user-images.githubusercontent.com/7688302/105725710-330d4800-5f21-11eb-991d-83058ad65bdd.png">

<img width="910" alt="image" src="https://user-images.githubusercontent.com/7688302/105725762-3e607380-5f21-11eb-9d7a-701a6b5f912a.png">