### PR TITLE
Add RSS feed link to <head>.

### DIFF
--- a/themes/plumerai-blog/layouts/partials/head.html
+++ b/themes/plumerai-blog/layouts/partials/head.html
@@ -46,4 +46,8 @@
     <meta property="og:image" content="{{ .Site.BaseURL }}{{ .Page.Params.socialImage }}">
     <meta name="twitter:image" content="{{ .Site.BaseURL }}{{ .Page.Params.socialImage }}">
     {{ end }}
+
+    {{ range .AlternativeOutputFormats -}}
+        {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+    {{ end -}}
 </head>


### PR DESCRIPTION
For the new Plumerai website we need to query recent blog posts; it would be useful if RSS could be used for that.

This follows the guidance from [the docs](https://gohugo.io/templates/rss/) to add the necessary link.

I tested it by pointing a local RSS reader to my localhost environment and seems to work.